### PR TITLE
Add release support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Node.js ZenHub Api
 You can find more samples in the test directory.
 
 ## Official documentation
-Can be foud [here](https://github.com/ZenHubIO/API)
+Can be found [here](https://github.com/ZenHubIO/API)
 
 
 ## Available methods
@@ -35,3 +35,11 @@ Can be foud [here](https://github.com/ZenHubIO/API)
 - [convertToEpic](https://github.com/ZenHubIO/API#convert-issue-to-epic)
 - [convertToIssue](https://github.com/ZenHubIO/API#convert-epic-to-issue)
 - [addOrRemoveToEpic](https://github.com/ZenHubIO/API#add-or-remove-issues-to-epic)
+- [createReleaseReport](https://github.com/ZenHubIO/API#create-a-release-report)
+- [getReleaseReport](https://github.com/ZenHubIO/API#get-a-release-report)
+- [getReleaseReportsForRepo](https://github.com/ZenHubIO/API#get-release-reports-for-a-repository)
+- [editReleaseReport](https://github.com/ZenHubIO/API#edit-a-release-report)
+- [addWorkspaceToReleaseReport](https://github.com/ZenHubIO/API#add-workspaces-to-a-release-report)
+- [removeWorkspaceFromReleaseReport](https://github.com/ZenHubIO/API#remove-workspaces-from-release-report)
+- [getReleaseReportIssues](https://github.com/ZenHubIO/API#get-all-the-issues-for-a-release-report)
+- [addOrRemoveToReleaseReport](https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mocha": "^3.2.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha test/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,38 @@ const API_ENDPOINTS = {
   addOrRemoveToEpic: {
     method: 'POST',
     path: '/repositories/:repo_id/epics/:issue_number/update_issues'
+  },
+  createReleaseReport: {
+    method: 'POST',
+    path: '/repositories/:repo_id/reports/release'
+  },
+  getReleaseReport: {
+    method: 'GET',
+    path: '/reports/release/:release_id'
+  },
+  getReleaseReportsForRepo: {
+    method: 'GET',
+    path: '/repositories/:repo_id/reports/releases'
+  },
+  editReleaseReport: {
+    method: 'PATCH',
+    path: '/reports/release/:release_id'
+  },
+  addWorkspaceToReleaseReport: {
+    method: 'PATCH',
+    path: '/reports/release/:release_id/workspaces/add'
+  },
+  removeWorkspaceFromReleaseReport: {
+    method: 'PATCH',
+    path: '/reports/release/:release_id/workspaces/remove'
+  },
+  getReleaseReportIssues: {
+    method: 'GET',
+    path: '/reports/release/:release_id/issues'
+  },
+  addOrRemoveToReleaseReport: {
+    method: 'PATCH',
+    path: '/reports/release/:release_id/issues'
   }
 };
 
@@ -51,6 +83,7 @@ function callServer(apiKey, params, endpoint) {
     .replace(':repo_id', params.repo_id)
     .replace(':issue_number', params.issue_number)
     .replace(':epic_id', params.epic_id)
+    .replace(':release_id', params.release_id)
   ;
 
   debug('%s %s with %o', endpoint.method, uri, params);

--- a/test/config.sample.json
+++ b/test/config.sample.json
@@ -1,7 +1,11 @@
 {
-  "apiKey": "apiKey",
+  "apiKey": apiKey,
   "repoId": repoId,
+  "secondRepoId": Need another repo to add/remove from workspace,
   "issueNumber": issueId,
-  "epicIssueNumber": epidIssueId,
-  "pipelineId": "move to this pipeline id"
+  "epicIssueNumber": epicIssueId,
+  "pipelineId": "move to this pipeline id",
+  "releaseTitle": "Test release",
+  "releaseDescription": "Test description",
+  "releaseId": Needs to be added here
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,34 +6,34 @@ describe('ZenHub', function() {
   const api = new ZenHub(conf.apiKey);
 
   it('should get issue data', function() {
-    return api.getIssueData({ 
+    return api.getIssueData({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber
     });
   });
 
   it('should get issue events', function() {
-    return api.getIssueEvents({ 
+    return api.getIssueEvents({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber
     });
   });
 
   it('should get board', function() {
-    return api.getBoard({ 
+    return api.getBoard({
       repo_id: conf.repoId
     });
   });
 
   it('should get epic data', function() {
-    return api.getEpicData({ 
+    return api.getEpicData({
       repo_id: conf.repoId,
       epic_id: conf.epicIssueNumber
     });
   });
 
   it('change pipeline', function() {
-    return api.changePipeline({ 
+    return api.changePipeline({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
       body: {
@@ -42,9 +42,9 @@ describe('ZenHub', function() {
       }
     });
   });
-  
+
   it('set estimate', function() {
-    return api.setEstimate({ 
+    return api.setEstimate({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
       body: {
@@ -52,23 +52,23 @@ describe('ZenHub', function() {
       }
     });
   });
-  
+
   it('convert to epic', function() {
-    return api.convertToEpic({ 
+    return api.convertToEpic({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
     });
   });
-  
+
   it('convert to issue', function() {
-    return api.convertToIssue({ 
+    return api.convertToIssue({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
     });
   });
 
   it('add to epic', function() {
-    return api.addOrRemoveToEpic({ 
+    return api.addOrRemoveToEpic({
       repo_id: conf.repoId,
       issue_number: conf.epicIssueNumber,
       body: {
@@ -83,7 +83,7 @@ describe('ZenHub', function() {
   });
 
   it('remove from epic', function() {
-    return api.addOrRemoveToEpic({ 
+    return api.addOrRemoveToEpic({
       repo_id: conf.repoId,
       issue_number: conf.epicIssueNumber,
       body: {
@@ -92,6 +92,90 @@ describe('ZenHub', function() {
             repo_id: parseInt(conf.repoId), //zenhub validators check field type, it must be numeric
             issue_number: parseInt(conf.issueNumber) //zenhub validators check field type, it must be numeric
           }
+        ]
+      }
+    });
+  });
+
+  it('create release report', function () {
+    return api.createReleaseReport({
+      repo_id: conf.repoId,
+      body: {
+        title: conf.releaseTitle
+      }
+    });
+  });
+
+  it('get release report', function () {
+    return api.getReleaseReport({
+      release_id: conf.releaseId
+    });
+  });
+
+  it('get release reports for repo', function () {
+    return api.getReleaseReportsForRepo({
+      repo_id: conf.repoId
+    });
+  });
+
+  it('edit release report', function () {
+    return api.editReleaseReport({
+      release_id: conf.releaseId,
+      body: {
+        description: conf.releaseDescription
+      }
+    });
+  });
+
+  it('add to release report', function () {
+    return api.addOrRemoveToReleaseReport({
+      release_id: conf.releaseId,
+      body: {
+        add_issues: [
+          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.issueNumber)},
+          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.epicIssueNumber)}
+        ],
+        remove_issues: []
+      }
+    });
+  });
+
+  it('get release report issues', function () {
+    return api.getReleaseReportIssues({
+      release_id: conf.releaseId
+    });
+  });
+
+  it('remove from release report', function () {
+    return api.addOrRemoveToReleaseReport({
+      release_id: conf.releaseId,
+      body: {
+        add_issues: [],
+        remove_issues: [
+          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.issueNumber)},
+          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.epicIssueNumber)}
+        ]
+      }
+    });
+  });
+
+  it('add workspace to release report', function () {
+    return api.addWorkspaceToReleaseReport({
+      release_id: conf.releaseId,
+      body: {
+        repositories: [
+          conf.secondRepoId
+        ]
+      }
+    });
+  });
+
+  it('remove workspace from release report', function () {
+    return api.removeWorkspaceFromReleaseReport({
+      release_id: conf.releaseId,
+      body: {
+        repositories: [
+          conf.secondRepoId
         ]
       }
     });


### PR DESCRIPTION
This adds release report support. 

To run the tests, the id of a second repo needs to be added to the test config but it can be any repo you have access to, so not sure if that's an issue?