### PR TITLE
Add support for enterprise ZenHub, use mocking for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Node.js ZenHub Api
 ```js
   const ZenHub = require('zenhub-api');
 
-  const api = new ZenHub(apiKey);
+  const api = new ZenHub(apiKey, [rootEndpoint]);
   api
     .getBoard({ repo_id: 01234 })
     .then((data) => {
@@ -17,6 +17,11 @@ Node.js ZenHub Api
     })
   ;
 ```
+
+
+
+The [root endpoint](https://github.com/ZenHubIO/API#root-endpoint) is only required for Enterprise ZenHub installations. It is likely to be https://zenhub-enterprise-host.
+
 You can find more samples in the test directory.
 
 ## Official documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,742 @@
+{
+  "name": "zenhub-api",
+  "version": "0.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.19"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "mime-db": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+    },
+    "mime-types": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "requires": {
+        "mime-db": "1.35.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nock": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.4.4.tgz",
+      "integrity": "sha512-HrF96ecwONEv7tW8bk79kwc9mshxWAw8WfEPv5LStc0X25bsoWgescTtmevFSetu3gdjOypnUtniubYSz+5DNA==",
+      "dev": true,
+      "requires": {
+        "chai": "4.1.2",
+        "debug": "3.1.0",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "propagate": "1.0.0",
+        "qs": "6.5.2",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "request": {
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.19",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "requires": {
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zenhub-api",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Wrapper for zenhub api",
   "main": "src/index.js",
   "dependencies": {
@@ -13,7 +13,8 @@
     "zenhub-api"
   ],
   "devDependencies": {
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "nock": "^9.4.4"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha test/index.js"

--- a/src/index.js
+++ b/src/index.js
@@ -1,90 +1,91 @@
 const request = require('request-promise-native');
 const debug   = require('debug')('ZenHub');
+const url     = require('url');
 
-const API_URL = 'https://api.zenhub.io/p1';
+const PUBLIC_API_ENDPOINT = 'https://api.zenhub.io';
 
 const API_ENDPOINTS = {
   getIssueData: {
     method: 'GET',
-    path: '/repositories/:repo_id/issues/:issue_number',
+    path: 'p1/repositories/:repo_id/issues/:issue_number',
   },
   getIssueEvents: {
     method: 'GET',
-    path: '/repositories/:repo_id/issues/:issue_number/events',
+    path: 'p1/repositories/:repo_id/issues/:issue_number/events',
   },
   getBoard: {
     method: 'GET',
-    path: '/repositories/:repo_id/board',
+    path: 'p1/repositories/:repo_id/board',
   },
   getEpics: {
     method: 'GET',
-    path: '/repositories/:repo_id/epics',
+    path: 'p1/repositories/:repo_id/epics',
   },
   getEpicData: {
     method: 'GET',
-    path: '/repositories/:repo_id/epics/:epic_id',
+    path: 'p1/repositories/:repo_id/epics/:epic_id',
   },
   changePipeline: {
     method: 'POST',
-    path: '/repositories/:repo_id/issues/:issue_number/moves',
+    path: 'p1/repositories/:repo_id/issues/:issue_number/moves',
   },
   setEstimate: {
     method: 'PUT',
-    path: '/repositories/:repo_id/issues/:issue_number/estimate'
+    path: 'p1/repositories/:repo_id/issues/:issue_number/estimate'
   },
   convertToEpic: {
     method: 'POST',
-    path: '/repositories/:repo_id/issues/:issue_number/convert_to_epic',
+    path: 'p1/repositories/:repo_id/issues/:issue_number/convert_to_epic',
   },
   convertToIssue: {
     method: 'POST',
-    path: '/repositories/:repo_id/epics/:issue_number/convert_to_issue',
+    path: 'p1/repositories/:repo_id/epics/:issue_number/convert_to_issue',
   },
   addOrRemoveToEpic: {
     method: 'POST',
-    path: '/repositories/:repo_id/epics/:issue_number/update_issues'
+    path: 'p1/repositories/:repo_id/epics/:issue_number/update_issues'
   },
   createReleaseReport: {
     method: 'POST',
-    path: '/repositories/:repo_id/reports/release'
+    path: 'p1/repositories/:repo_id/reports/release'
   },
   getReleaseReport: {
     method: 'GET',
-    path: '/reports/release/:release_id'
+    path: 'p1/reports/release/:release_id'
   },
   getReleaseReportsForRepo: {
     method: 'GET',
-    path: '/repositories/:repo_id/reports/releases'
+    path: 'p1/repositories/:repo_id/reports/releases'
   },
   editReleaseReport: {
     method: 'PATCH',
-    path: '/reports/release/:release_id'
+    path: 'p1/reports/release/:release_id'
   },
   addWorkspaceToReleaseReport: {
     method: 'PATCH',
-    path: '/reports/release/:release_id/workspaces/add'
+    path: 'p1/reports/release/:release_id/workspaces/add'
   },
   removeWorkspaceFromReleaseReport: {
     method: 'PATCH',
-    path: '/reports/release/:release_id/workspaces/remove'
+    path: 'p1/reports/release/:release_id/workspaces/remove'
   },
   getReleaseReportIssues: {
     method: 'GET',
-    path: '/reports/release/:release_id/issues'
+    path: 'p1/reports/release/:release_id/issues'
   },
   addOrRemoveToReleaseReport: {
     method: 'PATCH',
-    path: '/reports/release/:release_id/issues'
+    path: 'p1/reports/release/:release_id/issues'
   }
 };
 
-function callServer(apiKey, params, endpoint) {
-  const uri = API_URL + endpoint.path
+function callServer(apiKey, apiUrl, params, endpoint) {
+  const uri = url.resolve(apiUrl, endpoint.path
     .replace(':repo_id', params.repo_id)
     .replace(':issue_number', params.issue_number)
     .replace(':epic_id', params.epic_id)
     .replace(':release_id', params.release_id)
-  ;
+  );
 
   debug('%s %s with %o', endpoint.method, uri, params);
 
@@ -99,13 +100,14 @@ function callServer(apiKey, params, endpoint) {
   });
 }
 
-function ZenHub(apiKey) {
+function ZenHub(apiKey, apiUrl = PUBLIC_API_ENDPOINT) {
   this.apiKey = apiKey;
+  this.apiUrl = apiUrl;
 };
 
 Object.keys(API_ENDPOINTS).forEach(function(value) {
   ZenHub.prototype[value] = function(params) {
-    return callServer(this.apiKey, params, API_ENDPOINTS[value]);
+    return callServer(this.apiKey, this.apiUrl, params, API_ENDPOINTS[value]);
   };
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,66 @@
-const conf = require('./config.json');
 const ZenHub = require('../src/index.js');
+const nock = require('nock');
 const assert = require('assert');
+const url = require('url');
 
-describe('ZenHub', function() {
-  const api = new ZenHub(conf.apiKey);
+const PUBLIC_API_ENDPOINT = 'https://api.zenhub.io';
+
+var conf;
+try {
+  conf = require('./config.json');
+} catch (err) {
+  conf = {
+    nockOnly: true,
+    apiKey: 'test',
+    repoId: 1,
+    issueNumber: 2,
+    epicIssueNumber: 3,
+    pipelineId: 4,
+    releaseId: 5,
+    secondRepoId: 6,
+    releaseTitle: 'Release Title',
+    releaseDescription: 'Release Description'
+  }
+}
+
+describe('ZenHub public API with nock', () => {
+  addMethodTests();
+});
+describe('ZenHub enterprise API with nock', () => {
+  addMethodTests('https://zenhub.enterprise');
+});
+var public_connect = conf.nockOnly ? describe.skip : describe;
+public_connect('ZenHub public API', () => {
+  before(() => {
+    nock.restore();
+  });
+  addMethodTests();
+  after(() => {
+    nock.activate();
+    nock.cleanAll();
+  });
+});
+
+function addMethodTests(apiUrl) {
+  const api = new ZenHub(conf.apiKey, apiUrl);
+  const nockHeaders = {
+    reqheaders: {
+      'x-authentication-token': conf.apiKey,
+      'accept': 'application/json'
+    }
+  }
+
+  if (apiUrl === undefined) {
+    apiUrl = PUBLIC_API_ENDPOINT;
+  }
+  let apiUrlParts = url.parse(apiUrl);
+  let apiHostname = `${apiUrlParts.protocol}//${apiUrlParts.host}`;
+  let apiPath = apiUrlParts.pathname;
 
   it('should get issue data', function() {
+    nock(apiHostname, nockHeaders)
+      .get(url.resolve(apiPath, `p1/repositories/${conf.repoId}/issues/${conf.issueNumber}`))
+      .reply(200);
     return api.getIssueData({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber
@@ -13,6 +68,9 @@ describe('ZenHub', function() {
   });
 
   it('should get issue events', function() {
+    nock(apiHostname, nockHeaders)
+      .get(url.resolve(apiPath, `p1/repositories/${conf.repoId}/issues/${conf.issueNumber}/events`))
+      .reply(200);
     return api.getIssueEvents({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber
@@ -20,164 +78,250 @@ describe('ZenHub', function() {
   });
 
   it('should get board', function() {
+    nock(apiHostname, nockHeaders)
+      .get(url.resolve(apiPath, `p1/repositories/${conf.repoId}/board`))
+      .reply(200);
     return api.getBoard({
       repo_id: conf.repoId
     });
   });
 
   it('should get epic data', function() {
+    nock(apiHostname, nockHeaders)
+      .get(url.resolve(apiPath, `p1/repositories/${conf.repoId}/epics/${conf.epicIssueNumber}`))
+      .reply(200);
     return api.getEpicData({
       repo_id: conf.repoId,
       epic_id: conf.epicIssueNumber
     });
   });
 
-  it('change pipeline', function() {
+  it('should change pipeline', function() {
+    let body = { pipeline_id: conf.pipelineId, position: 'top' };
+    nock(apiHostname, nockHeaders)
+      .post(
+        url.resolve(apiPath, `p1/repositories/${conf.repoId}/issues/${conf.issueNumber}/moves`),
+        body
+      )
+      .reply(200);
     return api.changePipeline({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
-      body: {
-        pipeline_id: conf.pipelineId,
-        position: 'top'
-      }
+      body: body
     });
   });
 
-  it('set estimate', function() {
+  it('should set estimate', function() {
+    let body = { estimate: 15 };
+    nock(apiHostname, nockHeaders)
+      .put(
+        url.resolve(apiPath, `p1/repositories/${conf.repoId}/issues/${conf.issueNumber}/estimate`),
+        body
+      )
+      .reply(200);
     return api.setEstimate({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
-      body: {
-        estimate: 15
-      }
+      body: body
     });
   });
 
-  it('convert to epic', function() {
+  it('should convert issue to epic', function() {
+    nock(apiHostname, nockHeaders)
+      .post(url.resolve(apiPath, `p1/repositories/${conf.repoId}/issues/${conf.issueNumber}/convert_to_epic`))
+      .reply(200);
     return api.convertToEpic({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
     });
   });
 
-  it('convert to issue', function() {
+  it('should convert epic to issue', function() {
+    nock(apiHostname, nockHeaders)
+      .post(url.resolve(apiPath, `p1/repositories/${conf.repoId}/epics/${conf.issueNumber}/convert_to_issue`))
+      .reply(200);
     return api.convertToIssue({
       repo_id: conf.repoId,
       issue_number: conf.issueNumber,
     });
   });
 
-  it('add to epic', function() {
+  it('should add issue to epic', function() {
+    let body = {
+      add_issues: [
+        {
+          repo_id: parseInt(conf.repoId), //zenhub validators check field type, it must be numeric
+          issue_number: parseInt(conf.issueNumber) //zenhub validators check field type, it must be numeric
+        }
+      ]
+    }
+    nock(apiHostname, nockHeaders)
+      .post(
+        url.resolve(apiPath, `p1/repositories/${conf.repoId}/epics/${conf.epicIssueNumber}/update_issues`),
+        body
+      )
+      .reply(200);
     return api.addOrRemoveToEpic({
       repo_id: conf.repoId,
       issue_number: conf.epicIssueNumber,
-      body: {
-        add_issues: [
-          {
-            repo_id: parseInt(conf.repoId), //zenhub validators check field type, it must be numeric
-            issue_number: parseInt(conf.issueNumber) //zenhub validators check field type, it must be numeric
-          }
-        ]
-      }
+      body: body
     });
   });
 
-  it('remove from epic', function() {
+  it('should remove issue from epic', function() {
+    let body = {
+      remove_issues: [
+        {
+          repo_id: parseInt(conf.repoId), //zenhub validators check field type, it must be numeric
+          issue_number: parseInt(conf.issueNumber) //zenhub validators check field type, it must be numeric
+        }
+      ]
+    }
+    nock(apiHostname, nockHeaders)
+      .post(
+        url.resolve(apiPath, `p1/repositories/${conf.repoId}/epics/${conf.epicIssueNumber}/update_issues`),
+        body
+      )
+      .reply(200);
     return api.addOrRemoveToEpic({
       repo_id: conf.repoId,
       issue_number: conf.epicIssueNumber,
-      body: {
-        remove_issues: [
-          {
-            repo_id: parseInt(conf.repoId), //zenhub validators check field type, it must be numeric
-            issue_number: parseInt(conf.issueNumber) //zenhub validators check field type, it must be numeric
-          }
-        ]
-      }
+      body: body
     });
   });
 
-  it('create release report', function () {
+  it('should create release report', function () {
+    let body = {
+      title: conf.releaseTitle
+    };
+    nock(apiHostname, nockHeaders)
+      .post(
+        url.resolve(apiPath, `p1/repositories/${conf.repoId}/reports/release`),
+        body
+      )
+      .reply(200);
     return api.createReleaseReport({
       repo_id: conf.repoId,
-      body: {
-        title: conf.releaseTitle
-      }
+      body: body
     });
   });
 
-  it('get release report', function () {
+  it('should get release report', function () {
+    nock(apiHostname, nockHeaders)
+      .get(url.resolve(apiPath, `p1/reports/release/${conf.releaseId}`))
+      .reply(200);
     return api.getReleaseReport({
       release_id: conf.releaseId
     });
   });
 
-  it('get release reports for repo', function () {
+  it('should get release reports for repo', function () {
+    nock(apiHostname, nockHeaders)
+      .get(url.resolve(apiPath, `p1/repositories/${conf.repoId}/reports/releases`))
+      .reply(200);
     return api.getReleaseReportsForRepo({
       repo_id: conf.repoId
     });
   });
 
-  it('edit release report', function () {
+  it('should edit release report', function () {
+    let body = {
+      description: conf.releaseDescription
+    }
+    nock(apiHostname, nockHeaders)
+      .patch(
+        url.resolve(apiPath, `p1/reports/release/${conf.releaseId}`),
+        body
+      )
+      .reply(200);
     return api.editReleaseReport({
       release_id: conf.releaseId,
-      body: {
-        description: conf.releaseDescription
-      }
+      body: body
     });
   });
 
-  it('add to release report', function () {
+  it('should add to release report', function () {
+    let body = {
+      add_issues: [
+        { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.issueNumber)},
+        { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.epicIssueNumber)}
+      ],
+      remove_issues: []
+    }
+    nock(apiHostname, nockHeaders)
+      .patch(
+        url.resolve(apiPath, `p1/reports/release/${conf.releaseId}/issues`),
+        body
+      )
+      .reply(200);
     return api.addOrRemoveToReleaseReport({
       release_id: conf.releaseId,
-      body: {
-        add_issues: [
-          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.issueNumber)},
-          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.epicIssueNumber)}
-        ],
-        remove_issues: []
-      }
+      body: body
     });
   });
 
-  it('get release report issues', function () {
+  it('should get release report issues', function () {
+    nock(apiHostname, nockHeaders)
+      .get(url.resolve(apiPath, `p1/reports/release/${conf.releaseId}/issues`))
+      .reply(200);
     return api.getReleaseReportIssues({
       release_id: conf.releaseId
     });
   });
 
-  it('remove from release report', function () {
+  it('should remove from release report', function () {
+    let body = {
+      add_issues: [],
+      remove_issues: [
+        { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.issueNumber)},
+        { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.epicIssueNumber)}
+      ]
+    }
+    nock(apiHostname, nockHeaders)
+      .patch(
+        url.resolve(apiPath, `p1/reports/release/${conf.releaseId}/issues`),
+        body
+      )
+      .reply(200);
     return api.addOrRemoveToReleaseReport({
       release_id: conf.releaseId,
-      body: {
-        add_issues: [],
-        remove_issues: [
-          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.issueNumber)},
-          { repo_id: parseInt(conf.repoId), issue_number: parseInt(conf.epicIssueNumber)}
-        ]
-      }
+      body: body
     });
   });
 
-  it('add workspace to release report', function () {
+  it('should add workspace to release report', function () {
+    let body = {
+      repositories: [
+        conf.secondRepoId
+      ]
+    }
+    nock(apiHostname, nockHeaders)
+      .patch(
+        url.resolve(apiPath, `p1/reports/release/${conf.releaseId}/workspaces/add`),
+        body
+      )
+      .reply(200);
     return api.addWorkspaceToReleaseReport({
       release_id: conf.releaseId,
-      body: {
-        repositories: [
-          conf.secondRepoId
-        ]
-      }
+      body: body
     });
   });
 
-  it('remove workspace from release report', function () {
+  it('should remove workspace from release report', function () {
+    let body = {
+      repositories: [
+        conf.secondRepoId
+      ]
+    }
+    nock(apiHostname, nockHeaders)
+      .patch(
+        url.resolve(apiPath, `p1/reports/release/${conf.releaseId}/workspaces/remove`),
+        body
+      )
+      .reply(200);
     return api.removeWorkspaceFromReleaseReport({
       release_id: conf.releaseId,
-      body: {
-        repositories: [
-          conf.secondRepoId
-        ]
-      }
+      body: body
     });
   });
-});
+}


### PR DESCRIPTION
Added support for zenhub enterprise. I took the /p1 off the public endpoint in case the api gets extended to p2 in the future, which would leave enterprise users in a bad state (if we had asked them to pass in https://enterprise.zenhub/p1/).

Moved testing to nock. We don't actually test the returns from the public api, so just using nock is as good as what's there. I've put a default config file in to be able to run the tests with nock without needing to set up a config file and a public zenhub account. If a config file does exist, it'll use that instead and attempt to connect publicly to run real-world tests. I've abstracted the tests so that we can run the same batch of tests for each connection scenario.