### PR TITLE
Update API_URL to https://api.zenhub.com

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const request = require('request-promise-native');
 const debug   = require('debug')('ZenHub');
 
-const API_URL = 'https://api.zenhub.io/p1';
+const API_URL = 'https://api.zenhub.com/p1';
 
 const API_ENDPOINTS = {
   getIssueData: {


### PR DESCRIPTION
Received the following error when using `api.zenhub.io`:

```
(node:44426) UnhandledPromiseRejectionWarning: RequestError: Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames: Host: api.zenhub.io. is not in the cert's altnames: DNS:raptor-admin.zenhub.com
```

Contacted ZenHub and they stated that the `api.zenhub.io` domain is no longer supported and must be updated to `api.zenhub.com`